### PR TITLE
User story 3

### DIFF
--- a/app/controllers/shelter_reviews_controller.rb
+++ b/app/controllers/shelter_reviews_controller.rb
@@ -1,0 +1,18 @@
+class ShelterReviewsController < ApplicationController
+
+  def new
+    @shelter = Shelter.find(params[:shelter_id])
+  end
+
+  def create
+    @shelter = Shelter.find(params[:shelter_id])
+    @shelter.shelter_reviews.create(review_params)
+    redirect_to "/shelters/#{@shelter.id}"
+  end
+
+private
+
+  def review_params
+    params.permit(:title, :rating, :content, :image)
+  end
+end

--- a/app/views/shelter_reviews/new.html.erb
+++ b/app/views/shelter_reviews/new.html.erb
@@ -1,0 +1,17 @@
+<h1>Create New Review</h1>
+
+<%= form_tag "/shelters/#{@shelter.id}/reviews", method: :post do %>
+  <p><%= label_tag :title %></p>
+  <%= text_field_tag :title%>
+  <br>
+  <p><%= label_tag :rating %></p>
+  <%= text_field_tag :rating %>
+  <br>
+  <p><%= label_tag :content %></p>
+  <%= text_field_tag :content %>
+  <br>
+  <p><%= label_tag :image %> (optional)</p>
+  <%= text_field_tag :image %>
+  <br>
+  <%= submit_tag 'Create Review' %>
+<% end %>

--- a/app/views/shelters/show.html.erb
+++ b/app/views/shelters/show.html.erb
@@ -5,6 +5,7 @@
 <p>State: <%= @shelter.state %></p>
 <p>Zip: <%= @shelter.zip %></p>
 <hr>
+
 <h2>Reviews:</h2>
 <% @shelter.shelter_reviews.each do |review|%>
   <%=image_tag(review.image) %>
@@ -12,6 +13,8 @@
   <p>Rating: <%= review.rating %></p>
   <p>Content: <%= review.content %></p>
 <% end %>
+<p><%= link_to "New Review", "/shelters/#{@shelter.id}/reviews/new" %></p>
+
 <hr>
 
 <p><%= link_to "Shelter's Pets Page", "/shelters/#{@shelter.id}/pets" %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,9 +7,9 @@ Rails.application.routes.draw do
   get "/shelters/:id/edit", to: "shelters#edit"
   patch "/shelters/:id", to: "shelters#update"
   delete "/shelters/:id", to: "shelters#destroy"
-  
+
   get "/shelters/:id/pets", to: "shelter_pets#index"
-  
+
   get "/pets", to: "pets#index"
   get "/pets/:id", to: "pets#show"
   get "/shelters/:id/pets/new", to: "pets#new"
@@ -17,4 +17,7 @@ Rails.application.routes.draw do
   get "/pets/:id/edit", to: "pets#edit"
   post "/pets/:id", to: "pets#update"
   delete "/pets/:id", to: "pets#destroy"
+
+  get "/shelters/:shelter_id/reviews/new", to: "shelter_reviews#new"
+  post "/shelters/:shelter_id/reviews", to: "shelter_reviews#create"
 end

--- a/spec/features/shelter_reviews/new_spec.rb
+++ b/spec/features/shelter_reviews/new_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe "As a visitor", type: :feature do
+
+  before(:each) do
+    @shelter_1 = Shelter.create({
+            name: "Primary Shelter",
+            address: "123 Maple Ave.",
+            city: "Denver",
+            state: "CO",
+            zip: "80438"
+            })
+  end
+
+  it "I can create new shelter reviews" do
+
+    visit "/shelters/#{@shelter_1.id}"
+    expect(page).to have_link("New Review")
+
+    expect(page).to_not have_content("Review string")
+    expect(page).to_not have_content("Review rating")
+    expect(page).to_not have_content("Review content")
+
+    # expect(@shelter_1.reviews).to eq(nil)
+
+    click_on "New Review"
+
+    expect(current_path).to eq("/shelters/#{@shelter_1.id}/reviews/new")
+
+    fill_in 'Title', with: "Review string"
+    fill_in 'Rating', with: "Review rating"
+    fill_in 'Content', with: "Review content"
+    fill_in 'Image', with: "https://images.pexels.com/photos/1108099/pexels-photo-1108099.jpeg"
+
+    click_on "Create Review"
+    expect(current_path).to eq("/shelters/#{@shelter_1.id}")
+
+    expect(page).to have_content("Review string")
+    expect(page).to have_content("Review rating")
+    expect(page).to have_content("Review content")
+    # expect(page).to have_content("image placeholder")
+  end
+end
+    # User Story 3, Shelter Review Creation
+    #
+    # As a visitor,
+    # When I visit a shelter's show page
+    # I see a link to add a new review for this shelter.
+    # When I click on this link, I am taken to a new review path
+    # On this new page, I see a form where I must enter:
+    # - title
+    # - rating
+    # - content
+    # I also see a field where I can enter an optional image (web address)
+    # When the form is submitted, I should return to that shelter's show page
+    # and I can see my new review

--- a/user_stories.md
+++ b/user_stories.md
@@ -28,7 +28,7 @@ Each review will have:
 - an optional picture
 
 
-[ ] done
+[X] done
 
 User Story 3, Shelter Review Creation
 


### PR DESCRIPTION
User Story 3, Shelter Review Creation

As a visitor,
When I visit a shelter's show page
I see a link to add a new review for this shelter.
When I click on this link, I am taken to a new review path
On this new page, I see a form where I must enter:
- title
- rating
- content
I also see a field where I can enter an optional image (web address)
When the form is submitted, I should return to that shelter's show page
and I can see my new review