### PR TITLE
User story 4

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,8 +13,8 @@
  *= require_tree .
  *= require_self
  */
- 
-  
+
+
  body {
   background-color: #a7ecf2;
   font-family: "copperplate";
@@ -26,21 +26,37 @@
   	color: #743b1a;
   	font-family: "copperplate";
   }
-  
+
   h2 {
    text-align: left;
   	font-size: 30px;
   	color: #743b1a;
   	font-family: "copperplate";
   }
-  
+
   h3 {
    text-align: center;
     font-size: 55px;
     color: #743b1a;
     font-family: "copperplate";
   }
-  
+
+  h4 {
+   text-align: center;
+    font-size: 25px;
+    color: #743b1a;
+    font-family: "copperplate";
+    background-color: green;
+  }
+
+  h5 {
+   text-align: center;
+    font-size: 25px;
+    color: #743b1a;
+    font-family: "copperplate";
+    background-color: red;
+  }
+
   p {
    text-align: left;
     font-size: 20px;
@@ -181,7 +197,7 @@
  tr:nth-child(even) {
    background-color: #F0F8FF;
  }
- 
+
  /* unvisited link */
 a:link {
   color: #9a4f23;
@@ -200,4 +216,15 @@ a:hover {
 /* selected link */
 a:active {
   color: #b08e2c;
+}
+
+.error-flash {
+  padding: 10px;
+  background-color: red;
+  color: white;
+}
+.success-flash {
+  padding: 10px;
+  background-color: green;
+  color: white;
 }

--- a/app/controllers/shelter_reviews_controller.rb
+++ b/app/controllers/shelter_reviews_controller.rb
@@ -6,8 +6,14 @@ class ShelterReviewsController < ApplicationController
 
   def create
     @shelter = Shelter.find(params[:shelter_id])
-    @shelter.shelter_reviews.create(review_params)
-    redirect_to "/shelters/#{@shelter.id}"
+    review = @shelter.shelter_reviews.create(review_params)
+    if review.save
+      flash[:success] = "Review successfully created"
+      redirect_to "/shelters/#{@shelter.id}"
+    else
+      flash[:error] = "Review not created, please fill in a title, rating, and/or content"
+      render :new
+    end
   end
 
 private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,3 @@
 module ApplicationHelper
+
 end

--- a/app/models/shelter_review.rb
+++ b/app/models/shelter_review.rb
@@ -1,4 +1,8 @@
 class ShelterReview < ApplicationRecord
   belongs_to :shelter
-  
+  validates_presence_of :title,
+                        :rating,
+                        :content
+
+
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,8 @@
     <%= link_to "| Shelter Index |", "/shelters" %>
     </navbar>
     </nav>
-    <%= yield %>
+    <h4><%= flash[:success] %></h4>
+    <h5><%= flash[:error] %></h5>
+        <%= yield %>
   </body>
 </html>

--- a/app/views/shelter_reviews/new.html.erb
+++ b/app/views/shelter_reviews/new.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_tag "/shelters/#{@shelter.id}/reviews", method: :post do %>
   <p><%= label_tag :title %></p>
-  <%= text_field_tag :title%>
+  <%= text_field_tag :title %>
   <br>
   <p><%= label_tag :rating %></p>
   <%= text_field_tag :rating %>

--- a/spec/features/shelter_reviews/new_spec.rb
+++ b/spec/features/shelter_reviews/new_spec.rb
@@ -40,6 +40,16 @@ RSpec.describe "As a visitor", type: :feature do
     expect(page).to have_content("Review content")
     # expect(page).to have_content("image placeholder")
   end
+  it "I can not create a review without a name and receive a flash message" do
+    visit "/shelters/#{@shelter_1.id}/reviews/new"
+    click_on "Create Review"
+
+    save_and_open_page
+    expect(page).to have_content("Review not created, please fill in a title, rating, and/or content")
+    expect(page).to have_button("Create Review")
+
+    expect(current_path).to eq("/shelters/#{@shelter_1.id}/reviews/new")
+  end
 end
     # User Story 3, Shelter Review Creation
     #
@@ -54,3 +64,10 @@ end
     # I also see a field where I can enter an optional image (web address)
     # When the form is submitted, I should return to that shelter's show page
     # and I can see my new review
+
+    # User Story 4, Shelter Review Creation, cont.
+    #
+    # As a visitor,
+    # When I fail to enter a title, a rating, and/or content in the new shelter review form, but still try to submit the form
+    # I see a flash message indicating that I need to fill in a title, rating, and content in order to submit a shelter review
+    # And I'm returned to the new form to create a new review

--- a/user_stories.md
+++ b/user_stories.md
@@ -45,7 +45,7 @@ When the form is submitted, I should return to that shelter's show page
 and I can see my new review
 
 
-[ ] done
+[X] done
 
 User Story 4, Shelter Review Creation, cont.
 


### PR DESCRIPTION
User Story 4, Shelter Review Creation, cont.

As a visitor,
When I fail to enter a title, a rating, and/or content in the new shelter review form, but still try to submit the form
I see a flash message indicating that I need to fill in a title, rating, and content in order to submit a shelter review
And I'm returned to the new form to create a new review