### PR TITLE
User story 5

### DIFF
--- a/app/controllers/shelter_reviews_controller.rb
+++ b/app/controllers/shelter_reviews_controller.rb
@@ -12,8 +12,18 @@ class ShelterReviewsController < ApplicationController
       redirect_to "/shelters/#{@shelter.id}"
     else
       flash[:error] = "Review not created, please fill in a title, rating, and/or content"
-      render :new
+      redirect_to "/shelters/#{@shelter.id}/reviews/new"
     end
+  end
+
+  def edit
+    @shelter = Shelter.find(params[:shelter_id])
+    @review = ShelterReview.find(params[:review_id])
+  end
+
+  def update
+    review = ShelterReview.update(review_params)
+    redirect_to "/shelters/#{params[:shelter_id]}"
   end
 
 private

--- a/app/views/shelter_reviews/edit.html.erb
+++ b/app/views/shelter_reviews/edit.html.erb
@@ -1,0 +1,17 @@
+<h1>Edit Review</h1>
+
+<%= form_tag "/shelters/#{@shelter.id}/reviews/#{@review.id}/edit", method: :patch do %>
+  <p><%= label_tag :title %></p>
+  <%= text_field_tag :title, @review.title %>
+  <br>
+  <p><%= label_tag :rating %></p>
+  <%= text_field_tag :rating, @review.rating %>
+  <br>
+  <p><%= label_tag :content %></p>
+  <%= text_field_tag :content, @review.content %>
+  <br>
+  <p><%= label_tag :image %> (optional)</p>
+  <%= text_field_tag :image, @review.image %>
+  <br>
+  <%= submit_tag 'Update Review' %>
+<% end %>

--- a/app/views/shelters/show.html.erb
+++ b/app/views/shelters/show.html.erb
@@ -8,10 +8,12 @@
 
 <h2>Reviews:</h2>
 <% @shelter.shelter_reviews.each do |review|%>
-  <%=image_tag(review.image) %>
+  <img src= <%=review.image %>>
   <p>Title: <%= review.title %></p>
   <p>Rating: <%= review.rating %></p>
   <p>Content: <%= review.content %></p>
+  <p><%= link_to "Edit Review", "/shelters/#{@shelter.id}/reviews/#{review.id}/edit" %></p>
+<hr>
 <% end %>
 <p><%= link_to "New Review", "/shelters/#{@shelter.id}/reviews/new" %></p>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,4 +20,7 @@ Rails.application.routes.draw do
 
   get "/shelters/:shelter_id/reviews/new", to: "shelter_reviews#new"
   post "/shelters/:shelter_id/reviews", to: "shelter_reviews#create"
+  get "/shelters/:shelter_id/reviews/:review_id/edit", to: "shelter_reviews#edit"
+  patch "/shelters/:shelter_id/reviews/:review_id/edit", to: "shelter_reviews#update"
+
 end

--- a/spec/features/shelter_reviews/edit_spec.rb
+++ b/spec/features/shelter_reviews/edit_spec.rb
@@ -1,0 +1,64 @@
+# User Story 5, Edit a Shelter Review
+#
+# As a visitor,
+# When I visit a shelter's show page
+# I see a link to edit the shelter review next to each review.
+# When I click on this link, I am taken to an edit shelter review path
+# On this new page, I see a form that includes that review's pre populated data:
+# - title
+# - rating
+# - content
+# - image
+# I can update any of these fields and submit the form.
+# When the form is submitted, I should return to that shelter's show page
+# And I can see my updated review
+require 'rails_helper'
+
+RSpec.describe "As a visitor", type: :feature do
+
+  before(:each) do
+    @shelter_1 = Shelter.create({
+            name: "Primary Shelter",
+            address: "123 Maple Ave.",
+            city: "Denver",
+            state: "CO",
+            zip: "80438"
+            })
+    @shelter_2 = Shelter.create({
+            name: "Secondary Shelter",
+            address: "321 Oak Ave.",
+            city: "Casper",
+            state: "WY",
+            zip: "33221"
+            })
+    @review_1 = @shelter_1.shelter_reviews.create!(title: "Test title", rating: "5", content: "Test content", image: "https://cdn.pixabay.com/photo/2018/03/31/06/31/dog-3277416_960_720.jpg")
+  end
+
+  it "When I visit /shelters/:id, there is a link to edit each of the shelters reviews" do
+
+    visit "/shelters/#{@shelter_1.id}"
+
+    expect(page).to have_link("Edit Review")
+
+    click_on("Edit Review")
+    expect(current_path).to eq("/shelters/#{@shelter_1.id}/reviews/#{@review_1.id}/edit")
+    expect(find_field('Title').value).to eq(@review_1.title)
+    expect(find_field('Rating').value).to eq(@review_1.rating)
+    expect(find_field('Content').value).to eq(@review_1.content)
+    expect(find_field('Image').value).to eq(@review_1.image)
+
+    fill_in 'Title', with: "Updated title"
+    fill_in 'Rating', with: "Updated rating"
+    fill_in 'Content', with: "Updated content"
+    fill_in 'Image', with: "https://images.pexels.com/photos/1108099/pexels-photo-1108099.jpeg"
+
+    click_on("Update Review")
+    expect(current_path).to eq("/shelters/#{@shelter_1.id}")
+
+    expect(page).to have_content("Updated title")
+    expect(page).to have_content("Updated rating")
+    expect(page).to have_content("Updated content")
+    # expect(page).to have_css("img[src*='#{@review_1.image}']")
+
+  end
+end

--- a/spec/features/shelter_reviews/new_spec.rb
+++ b/spec/features/shelter_reviews/new_spec.rb
@@ -44,7 +44,6 @@ RSpec.describe "As a visitor", type: :feature do
     visit "/shelters/#{@shelter_1.id}/reviews/new"
     click_on "Create Review"
 
-    save_and_open_page
     expect(page).to have_content("Review not created, please fill in a title, rating, and/or content")
     expect(page).to have_button("Create Review")
 


### PR DESCRIPTION
User Story 5, Edit a Shelter Review

As a visitor,
When I visit a shelter's show page
I see a link to edit the shelter review next to each review.
When I click on this link, I am taken to an edit shelter review path
On this new page, I see a form that includes that review's pre populated data:
- title
- rating
- content
- image
I can update any of these fields and submit the form.
When the form is submitted, I should return to that shelter's show page
And I can see my updated review