### PR TITLE
User story 7

### DIFF
--- a/app/controllers/shelter_reviews_controller.rb
+++ b/app/controllers/shelter_reviews_controller.rb
@@ -32,6 +32,12 @@ class ShelterReviewsController < ApplicationController
       render :edit
     end
   end
+  
+  def destroy
+    ShelterReview.destroy(params[:review_id])
+    flash[:success] = "Review successfully deleted"
+    redirect_to "/shelters/#{params[:shelter_id]}"
+  end
 
 private
 

--- a/app/views/shelters/show.html.erb
+++ b/app/views/shelters/show.html.erb
@@ -7,14 +7,21 @@
 <hr>
 
 <h2>Reviews:</h2>
-<% @shelter.shelter_reviews.each do |review|%>
-  <img src= <%=review.image %>>
-  <p>Title: <%= review.title %></p>
-  <p>Rating: <%= review.rating %></p>
-  <p>Content: <%= review.content %></p>
-  <p><%= link_to "Edit Review", "/shelters/#{@shelter.id}/reviews/#{review.id}/edit" %></p>
-<hr>
-<% end %>
+  <div id = "reviews">
+    <% @shelter.shelter_reviews.each do |review|%>
+      <div id= "review-<%=review.id%>">
+        <img src= <%=review.image %>>
+        <p>Title: <%= review.title %></p>
+        <p>Rating: <%= review.rating %></p>
+        <p>Content: <%= review.content %></p>
+      </div>
+      <p><%= link_to "Edit Review", "/shelters/#{@shelter.id}/reviews/#{review.id}/edit" %></p>
+      <p><%= link_to "Delete Review", "/shelters/#{@shelter.id}/reviews/#{review.id}", method: :delete%></p>
+      <hr>
+    <% end %>
+  </div>
+
+
 <p><%= link_to "New Review", "/shelters/#{@shelter.id}/reviews/new" %></p>
 
 <hr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get "*path" => redirect("/")
+  
   get "/", to: "welcome#index"
   get "/shelters", to: "shelters#index"
   get "/shelters/new", to: "shelters#new"
@@ -22,5 +24,5 @@ Rails.application.routes.draw do
   post "/shelters/:shelter_id/reviews", to: "shelter_reviews#create"
   get "/shelters/:shelter_id/reviews/:review_id/edit", to: "shelter_reviews#edit"
   patch "/shelters/:shelter_id/reviews/:review_id/edit", to: "shelter_reviews#update"
-
+  delete "/shelters/:shelter_id/reviews/:review_id", to: "shelter_reviews#destroy"
 end

--- a/spec/features/shelter_reviews/destroy_spec.rb
+++ b/spec/features/shelter_reviews/destroy_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe "As a visitor", type: :feature do
+
+  before(:each) do
+    @shelter_1 = Shelter.create({
+            name: "Primary Shelter",
+            address: "123 Maple Ave.",
+            city: "Denver",
+            state: "CO",
+            zip: "80438"
+            })
+
+    @review_1 = @shelter_1.shelter_reviews.create!(title: "Test1 title", rating: "5", content: "Test1 content", image: "https://cdn.pixabay.com/photo/2018/03/31/06/31/dog-3277416_960_720.jpg")
+    @review_2 = @shelter_1.shelter_reviews.create!(title: "Test2 title", rating: "3", content: "Test2 content")
+    @review_3 = @shelter_1.shelter_reviews.create!(title: "Test3 title", rating: "1", content: "Test3 content", image: "https://cdn.pixabay.com/photo/2018/03/31/06/31/dog-3277416_960_720.jpg")
+  end
+
+  it "When I visit /shelters/:id, there is a link to delete each of the shelters reviews" do
+
+    visit "/shelters/#{@shelter_1.id}"
+    
+    expect(page).to have_link("Delete Review")
+    expect(page).to have_content(@review_1.title)
+    expect(page).to have_content(@review_2.title)
+    expect(page).to have_content(@review_3.title)
+    expect(page).to have_content(@review_1.rating)
+    expect(page).to have_content(@review_2.rating)
+    expect(page).to have_content(@review_3.rating)
+    expect(page).to have_content(@review_1.content)
+    expect(page).to have_content(@review_2.content)
+    expect(page).to have_content(@review_3.content)
+    # expect(page).to have_content(@review_1.image)
+    # expect(page).to_not have_content(@review_2.image)
+    # expect(page).to have_content(@review_3.image)
+
+    click_link("Delete Review", match: :first)
+    
+    expect(current_path).to eq("/shelters/#{@shelter_1.id}")
+    
+    expect(page).to have_link("Delete Review")
+    expect(page).to_not have_content(@review_1.title)
+    expect(page).to have_content(@review_2.title)
+    expect(page).to have_content(@review_3.title)
+    expect(page).to_not have_content(@review_1.rating)
+    expect(page).to have_content(@review_2.rating)
+    expect(page).to have_content(@review_3.rating)
+    expect(page).to_not have_content(@review_1.content)
+    expect(page).to have_content(@review_2.content)
+    expect(page).to have_content(@review_3.content)
+    # expect(page).to_not have_content(@review_1.image)
+    # expect(page).to_not have_content(@review_2.image)
+    # expect(page).to have_content(@review_3.image)
+
+  end
+end

--- a/user_stories.md
+++ b/user_stories.md
@@ -55,7 +55,7 @@ I see a flash message indicating that I need to fill in a title, rating, and con
 And I'm returned to the new form to create a new review
 
 
-[ ] done
+[x] done
 
 User Story 5, Edit a Shelter Review
 
@@ -73,7 +73,7 @@ When the form is submitted, I should return to that shelter's show page
 And I can see my updated review
 
 
-[ ] done
+[x] done
 
 User Story 6, Edit a Shelter Review, cont.
 
@@ -83,7 +83,7 @@ I see a flash message indicating that I need to fill in a title, rating, and con
 And I'm returned to the edit form to edit that review
 
 
-[ ] done
+[x] done
 
 User Story 7, Delete a Shelter Review
 
@@ -92,6 +92,8 @@ When I visit a shelter's show page,
 I see a link next to each shelter review to delete the review.
 When I delete a shelter review I am returned to the shelter's show page
 And I should no longer see that shelter review
+
+
 Favorite a Pet
 
 Users will be able to favorite a pet and keep track of pet's they're interested in


### PR DESCRIPTION
User Story 7, Delete a Shelter Review

As a visitor,
When I visit a shelter's show page,
I see a link next to each shelter review to delete the review.
When I delete a shelter review I am returned to the shelter's show page
And I should no longer see that shelter review