### PR TITLE
User story 10 & 11

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,5 +1,12 @@
 class FavoritesController < ApplicationController
 
+  def index
+    @favorites = []
+    favorite_pets.create_array.each do |pet|
+      @favorites << Pet.find(pet)
+    end
+  end
+
   def update
     pet = Pet.find(params[:pet_id])
     pet_id_str = pet.id.to_s
@@ -13,4 +20,6 @@ class FavoritesController < ApplicationController
       redirect_to "/pets/#{pet.id}"
     end
   end
+
+
 end

--- a/app/poros/favorites.rb
+++ b/app/poros/favorites.rb
@@ -13,4 +13,8 @@ class Favorites
     @favorite_pets.include?(pet_id)
   end
 
+  def create_array
+    @favorite_pets.map(&:to_i)
+  end
+
 end

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -1,0 +1,9 @@
+<hr>
+<h1>Favorites:</h1>
+
+<hr>
+<% @favorites.each do |pet| %>
+  <%= image_tag(pet.image, alt: "pet picture", method: :get, class: 'pet-image') %>
+  <h2>Name: <%= link_to "#{pet.name}", "/pets/#{pet.id}" %></h2>
+  <hr>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,7 @@
         <%= link_to "| Home |", "/" %>
         <%= link_to "| Pet Index |", "/pets" %>
         <%= link_to "| Shelter Index |", "/shelters" %>
-        <%= link_to "| Favorites - #{favorite_pets.total} |", "/" %>
+        <%= link_to "| Favorites - #{favorite_pets.total} |", "/favorites" %>
       </navbar>
     </section>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,4 +25,5 @@ Rails.application.routes.draw do
   delete "/shelters/:shelter_id/reviews/:review_id", to: "shelter_reviews#destroy"
 
   patch '/pets/:pet_id/', to: "favorites#update"
+  get '/favorites', to: "favorites#index"
 end

--- a/spec/features/favorites/index_spec.rb
+++ b/spec/features/favorites/index_spec.rb
@@ -1,0 +1,72 @@
+# User Story 10, Favorite Index Page
+#
+# As a visitor
+# When I have added pets to my favorites list
+# And I visit my favorites index page ("/favorites")
+# I see all pets I've favorited
+# Each pet in my favorites shows the following information:
+# - pet's name (link to pets show page)
+# - pet's image
+require 'rails_helper'
+
+RSpec.describe "As a visitor", type: :feature do
+
+  before(:each) do
+    @shelter_1 = Shelter.create({
+            name: "Primary Shelter",
+            address: "123 Maple Ave.",
+            city: "Denver",
+            state: "CO",
+            zip: "80438"
+            })
+
+    @pet_1 = @shelter_1.pets.create!(
+              image: "https://allaboutshepherds.com/wp-content/uploads/2016/05/gsd-canoe.jpg",
+              name: "Bailey",
+              age: "3",
+              sex: "Female",
+              description: "She's a 85 pound lap dog!",
+              status: "Adoptable"
+              )
+
+    @pet_2 = @shelter_1.pets.create!(
+              image: "https://i.pinimg.com/originals/ea/cd/6a/eacd6a5cbcf58c93fa4cfc4d83159896.jpg",
+              name: "Bruiser",
+              age: "2",
+              sex: "Male",
+              description: "He's a 185 pound lap dog!",
+              status: "Adoptable"
+              )
+  end
+
+  it "I visit my favorites index page I see all pets I've favorited" do
+
+    visit "/pets/#{@pet_1.id}"
+    expect(current_path).to eq("/pets/#{@pet_1.id}")
+    expect(page).to have_link("Add to Favorites")
+    click_link("Add to Favorites")
+    expect(current_path).to eq("/pets/#{@pet_1.id}")
+
+    within "navbar" do
+      expect(page).to have_link("Favorites - 1")
+    end
+
+    visit "/pets/#{@pet_2.id}"
+    expect(current_path).to eq("/pets/#{@pet_2.id}")
+    expect(page).to have_link("Add to Favorites")
+    click_link("Add to Favorites")
+    expect(current_path).to eq("/pets/#{@pet_2.id}")
+
+    within "navbar" do
+      expect(page).to have_link("Favorites - 2")
+      click_link "Favorites - 2"
+    end
+
+    expect(current_path).to eq("/favorites")
+
+    expect(page).to have_content("#{@pet_1.name}")
+    expect(page).to have_css("img[src*='#{@pet_1.image}']")
+    expect(page).to have_content("#{@pet_2.name}")
+    expect(page).to have_css("img[src*='#{@pet_2.image}']")
+  end
+end

--- a/user_stories.md
+++ b/user_stories.md
@@ -99,7 +99,7 @@ Favorite a Pet
 Users will be able to favorite a pet and keep track of pet's they're interested in
 
 
-[ ] done
+[x] done
 
 User Story 8, Favorite Indicator
 
@@ -109,7 +109,7 @@ The favorite indicator shows a count of pets in my favorites list
 I can see this favorite indicator from any page in the application
 
 
-[ ] done
+[x] done
 
 User Story 9, Favorite Creation
 
@@ -122,7 +122,7 @@ I see a flash message indicating that the pet has been added to my favorites lis
 The favorite indicator in the nav bar has incremented by one
 
 
-[ ] done
+[x] done
 
 User Story 10, Favorite Index Page
 
@@ -135,7 +135,7 @@ Each pet in my favorites shows the following information:
 - pet's image
 
 
-[ ] done
+[x] done
 
 User Story 11, Favorite Indicator links to Index Page
 


### PR DESCRIPTION
User Story 10, Favorite Index Page

As a visitor
When I have added pets to my favorites list
And I visit my favorites index page ("/favorites")
I see all pets I've favorited
Each pet in my favorites shows the following information:
- pet's name (link to pets show page)
- pet's image
[ ] done

User Story 11, Favorite Indicator links to Index Page

As a visitor
When I click on the favorite indicator in the nav bar
I am taken to the favorites index page