### PR TITLE
User story 12

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -20,6 +20,12 @@ class FavoritesController < ApplicationController
       redirect_to "/pets/#{pet.id}"
     end
   end
-
+    
+  def destroy
+    pet = Pet.find(params[:pet_id])
+    session[:favorites].delete(pet.id.to_s)
+    flash[:notice] = "Success, #{pet.name} has been removed from your favorites!"
+    redirect_to "/pets/#{pet.id}"
+  end
 
 end

--- a/app/poros/favorites.rb
+++ b/app/poros/favorites.rb
@@ -10,11 +10,12 @@ class Favorites
   end
 
   def favorited?(pet_id)
-    @favorite_pets.include?(pet_id)
+    @favorite_pets.include?(pet_id.to_s)
   end
 
   def create_array
     @favorite_pets.map(&:to_i)
   end
+
 
 end

--- a/app/views/pets/show.html.erb
+++ b/app/views/pets/show.html.erb
@@ -6,7 +6,11 @@
 <p>Sex: <%= @pet.sex %></p>
 <p>Adoption Status: <%= @pet.status %></p>
 <hr>
-<p><%= link_to "Add to Favorites", "/pets/#{@pet.id}", method: :patch %></p>
+<% if favorite_pets.favorited?(@pet.id) %>
+  <p><%= link_to "Remove from Favorites", "/favorites/#{@pet.id}", method: :delete %></p>
+<% else %>
+  <p><%= link_to "Add to Favorites", "/pets/#{@pet.id}", method: :patch %></p>
+<% end %>
 <p><%= link_to "Update Pet", "/pets/#{@pet.id}/edit" %></p>
 <p><%= link_to "Delete Pet", "/pets/#{@pet.id}", method: :delete %></p>
 <hr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,4 +26,5 @@ Rails.application.routes.draw do
 
   patch '/pets/:pet_id/', to: "favorites#update"
   get '/favorites', to: "favorites#index"
+  delete "/favorites/:pet_id", to: "favorites#destroy"
 end

--- a/spec/features/favorites/delete_spec.rb
+++ b/spec/features/favorites/delete_spec.rb
@@ -1,0 +1,71 @@
+
+require 'rails_helper'
+
+RSpec.describe "As a visitor", type: :feature do
+
+  before(:each) do
+    @shelter_1 = Shelter.create({
+            name: "Primary Shelter",
+            address: "123 Maple Ave.",
+            city: "Denver",
+            state: "CO",
+            zip: "80438"
+            })
+
+    @pet_1 = @shelter_1.pets.create!(
+              image: "https://allaboutshepherds.com/wp-content/uploads/2016/05/gsd-canoe.jpg",
+              name: "Bailey",
+              age: "3",
+              sex: "Female",
+              description: "She's a 85 pound lap dog!",
+              status: "Adoptable"
+              )
+  end
+
+  it "I see a button or link to un-favorite that pet" do
+
+    visit "/pets/#{@pet_1.id}"
+    
+    within "navbar" do
+      expect(page).to have_link("Favorites - 0")
+    end
+    
+    expect(page).to have_content("Add to Favorites")
+
+    click_link "Add to Favorites"
+    
+    expect(current_path).to eq("/pets/#{@pet_1.id}")
+    
+    within "navbar" do
+      expect(page).to have_link("Favorites - 1")
+    end
+    
+    expect(page).to_not have_link("Add to Favorites")
+    expect(page).to have_link("Remove from Favorites")
+  
+    click_link 'Remove from Favorites'
+    
+    within("navbar") do
+      expect(page).to have_link("Favorites - 0")
+    end
+    
+    
+    expect(current_path).to eq("/pets/#{@pet_1.id}")
+    expect(page).to have_content("Success, #{@pet_1.name} has been removed from your favorites!")
+  end
+end
+
+
+
+# User Story 12, Can't Favorite a Pet More Than Once
+#
+# As a visitor
+# After I've favorited a pet
+# When I visit that pet's show page
+# I no longer see a link to favorite that pet
+# But I see a link to remove that pet from my favorites
+# When I click that link
+# A delete request is sent to "/favorites/:pet_id"
+# And I'm redirected back to that pets show page where I can see a flash message indicating that the pet was removed from my favorites
+# And I can now see a link to favorite that pet
+# And I also see that my favorites indicator has decremented by 1

--- a/spec/features/favorites/new_spec.rb
+++ b/spec/features/favorites/new_spec.rb
@@ -1,12 +1,3 @@
-# User Story 9, Favorite Creation
-#
-# As a visitor
-# When I visit a pet's show page
-# I see a button or link to favorite that pet
-# When I click the button or link
-# I'm taken back to that pet's show page
-# I see a flash message indicating that the pet has been added to my favorites list
-# The favorite indicator in the nav bar has incremented by one
 require 'rails_helper'
 
 RSpec.describe "As a visitor", type: :feature do

--- a/user_stories.md
+++ b/user_stories.md
@@ -144,7 +144,7 @@ When I click on the favorite indicator in the nav bar
 I am taken to the favorites index page
 
 
-[ ] done
+[x] done
 
 User Story 12, Can't Favorite a Pet More Than Once
 


### PR DESCRIPTION
[x] done

User Story 12, Can't Favorite a Pet More Than Once

As a visitor
After I've favorited a pet
When I visit that pet's show page
I no longer see a link to favorite that pet
But I see a link to remove that pet from my favorites
When I click that link
A delete request is sent to "/favorites/:pet_id"
And I'm redirected back to that pets show page where I can see a flash message indicating that the pet was removed from my favorites
And I can now see a link to favorite that pet
And I also see that my favorites indicator has decremented by 1