### PR TITLE
User story 13

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -20,12 +20,16 @@ class FavoritesController < ApplicationController
       redirect_to "/pets/#{pet.id}"
     end
   end
-    
+
   def destroy
     pet = Pet.find(params[:pet_id])
     session[:favorites].delete(pet.id.to_s)
     flash[:notice] = "Success, #{pet.name} has been removed from your favorites!"
-    redirect_to "/pets/#{pet.id}"
+    if URI(request.referer).path == "/favorites"
+      redirect_to "/favorites"
+    else
+      redirect_to "/pets/#{pet.id}"
+    end
   end
 
 end

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -5,5 +5,6 @@
 <% @favorites.each do |pet| %>
   <%= image_tag(pet.image, alt: "pet picture", method: :get, class: 'pet-image') %>
   <h2>Name: <%= link_to "#{pet.name}", "/pets/#{pet.id}" %></h2>
+  <p><%= link_to "Remove from Favorites", "/favorites/#{pet.id}", method: :delete %></p>
   <hr>
 <% end %>

--- a/spec/features/favorites/delete_spec.rb
+++ b/spec/features/favorites/delete_spec.rb
@@ -25,33 +25,55 @@ RSpec.describe "As a visitor", type: :feature do
   it "I see a button or link to un-favorite that pet" do
 
     visit "/pets/#{@pet_1.id}"
-    
+
     within "navbar" do
       expect(page).to have_link("Favorites - 0")
     end
-    
+
     expect(page).to have_content("Add to Favorites")
 
     click_link "Add to Favorites"
-    
+
     expect(current_path).to eq("/pets/#{@pet_1.id}")
-    
+
     within "navbar" do
       expect(page).to have_link("Favorites - 1")
     end
-    
+
     expect(page).to_not have_link("Add to Favorites")
     expect(page).to have_link("Remove from Favorites")
-  
+
     click_link 'Remove from Favorites'
-    
+
     within("navbar") do
       expect(page).to have_link("Favorites - 0")
     end
-    
-    
+
+
     expect(current_path).to eq("/pets/#{@pet_1.id}")
     expect(page).to have_content("Success, #{@pet_1.name} has been removed from your favorites!")
+  end
+
+  it "From my favorites page, I see a button or link to remove that pet from my favorites" do
+
+    visit "/pets/#{@pet_1.id}"
+    expect(page).to have_link("Add to Favorites")
+    click_link("Add to Favorites")
+    within "navbar" do
+      expect(page).to have_link("Favorites - 1")
+    end
+
+    click_link("Favorites - 1")
+    expect(current_path).to eq("/favorites")
+    expect(page).to have_content("Remove from Favorites")
+    # need to have a within here to specify if multiple?
+    click_link("Remove from Favorites")
+    expect(page).to have_content("Success, #{@pet_1.name} has been removed from your favorites!")
+
+    expect(current_path).to eq("/favorites")
+    within "navbar" do
+      expect(page).to have_link("Favorites - 0")
+    end
   end
 end
 
@@ -69,3 +91,15 @@ end
 # And I'm redirected back to that pets show page where I can see a flash message indicating that the pet was removed from my favorites
 # And I can now see a link to favorite that pet
 # And I also see that my favorites indicator has decremented by 1
+
+
+# User Story 13, Remove a Favorite from Favorites Page
+#
+# As a visitor
+# When I have added pets to my favorites list
+# And I visit my favorites page ("/favorites")
+# Next to each pet, I see a button or link to remove that pet from my favorites
+# When I click on that button or link to remove a favorite
+# A delete request is sent to "/favorites/:pet_id"
+# And I'm redirected back to the favorites page where I no longer see that pet listed
+# And I also see that the favorites indicator has decremented by 1


### PR DESCRIPTION
User Story 13, Remove a Favorite from Favorites Page

As a visitor
When I have added pets to my favorites list
And I visit my favorites page ("/favorites")
Next to each pet, I see a button or link to remove that pet from my favorites
When I click on that button or link to remove a favorite
A delete request is sent to "/favorites/:pet_id"
And I'm redirected back to the favorites page where I no longer see that pet listed
And I also see that the favorites indicator has decremented by 1