### PR TITLE
User story 15

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -22,9 +22,14 @@ class FavoritesController < ApplicationController
   end
 
   def destroy
-    pet = Pet.find(params[:pet_id])
-    session[:favorites].delete(pet.id.to_s)
-    flash[:success] = "Success, #{pet.name} has been removed from your favorites!"
+    if params[:pet_id] == "-1"
+      session[:favorites] = []
+      flash[:success] = "Success, all pets have been removed from your favorites!"
+    else
+      pet = Pet.find(params[:pet_id])
+      session[:favorites].delete(pet.id.to_s)
+      flash[:success] = "Success, #{pet.name} has been removed from your favorites!"
+    end
     if URI(request.referer).path == "/favorites"
       redirect_to "/favorites"
     else

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -4,6 +4,7 @@
     <h2><center>You have no favorited pets!</center></h2>
 <% else %>
 <h1>Favorites:</h1>
+<p><%= link_to "Remove All Favorited Pets", "/favorites/-1", method: :delete %></p>
 <hr>
   <% @favorites.each do |pet| %>
     <%= image_tag(pet.image, alt: "pet picture", method: :get, class: 'pet-image') %>

--- a/spec/features/favorites/delete_spec.rb
+++ b/spec/features/favorites/delete_spec.rb
@@ -75,8 +75,55 @@ RSpec.describe "As a visitor", type: :feature do
       expect(page).to have_link("Favorites - 0")
     end
   end
+
+  it "From my favorites page, I see a link to remove all favorited pets" do
+
+    pet_2 = @shelter_1.pets.create!(
+              image: "https://i.pinimg.com/originals/ea/cd/6a/eacd6a5cbcf58c93fa4cfc4d83159896.jpg",
+              name: "Bruiser",
+              age: "2",
+              sex: "Male",
+              description: "He's a 185 pound lap dog!",
+              status: "Adoptable"
+              )
+
+    visit "/pets/#{@pet_1.id}"
+    expect(page).to have_link("Add to Favorites")
+    click_link("Add to Favorites")
+    within "navbar" do
+      expect(page).to have_link("Favorites - 1")
+    end
+
+    visit "/pets/#{pet_2.id}"
+    expect(page).to have_link("Add to Favorites")
+    click_link("Add to Favorites")
+    within "navbar" do
+      expect(page).to have_link("Favorites - 2")
+    end
+
+    click_link("Favorites - 2")
+    expect(current_path).to eq("/favorites")
+    expect(page).to have_content("Remove All Favorited Pets")
+    click_link("Remove All Favorited Pets")
+
+    expect(current_path).to eq("/favorites")
+    expect(page).to have_content("Success, all pets have been removed from your favorites!")
+    within "navbar" do
+      expect(page).to have_link("Favorites - 0")
+    end
+  end
 end
 
+# User Story 15, Remove all Favorite from Favorites Page
+#
+# As a visitor
+# When I have added pets to my favorites list
+# And I visit my favorites page ("/favorites")
+# I see a link to remove all favorited pets
+# When I click that link
+# I'm redirected back to the favorites page
+# I see the text saying that I have no favorited pets
+# And the favorites indicator returns to 0
 
 
 # User Story 12, Can't Favorite a Pet More Than Once


### PR DESCRIPTION
User Story 15, Remove all Favorite from Favorites Page

As a visitor
When I have added pets to my favorites list
And I visit my favorites page ("/favorites")
I see a link to remove all favorited pets
When I click that link
I'm redirected back to the favorites page
I see the text saying that I have no favorited pets
And the favorites indicator returns to 0