### PR TITLE
User story 22 & 23

### DIFF
--- a/app/controllers/pet_adoptions_controller.rb
+++ b/app/controllers/pet_adoptions_controller.rb
@@ -1,7 +1,15 @@
 class PetAdoptionsController < ApplicationController
-  
+
   def index
     @pet = Pet.find(params[:id])
   end
-  
+
+  def update
+    @pet = Pet.find(params[:pet_id])
+    @pet_adoption = PetAdoption.find(params[:pet_adoption_id])
+    @pet_adoption.update(status: "Pending")
+    @pet.update(status: "Pending")
+    redirect_to "/pets/#{params[:pet_id]}"
+  end
+
 end

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -1,17 +1,18 @@
 class PetsController < ApplicationController
-  
+
   def index
     @pets = Pet.all
   end
-  
+
   def show
     @pet = Pet.find(params[:id])
+    @pending_apps = PetAdoption.where(['pet_id = ? and status = ?', "#{@pet.id}", "Pending"])
   end
-  
+
   def new
     @shelter = Shelter.find(params[:id])
   end
-  
+
   def create
     shelter = Shelter.find(params[:id])
     new_pet = shelter.pets.create(pet_params)
@@ -24,11 +25,11 @@ class PetsController < ApplicationController
       # render :new
     end
   end
-  
+
   def edit
     @pet = Pet.find(params[:id])
   end
-  
+
   def update
     pet = Pet.find(params[:id])
     missing_fields = pet_params.select{|_,user_input| user_input.nil? || user_input == ""}.keys
@@ -40,7 +41,7 @@ class PetsController < ApplicationController
       # redirect_to "/pets/#{params[:id]}/edit"
     end
   end
-  
+
   def destroy
     pet = Pet.find(params[:id])
     if pet.status == "Pending"
@@ -52,9 +53,9 @@ class PetsController < ApplicationController
       redirect_to "/pets"
     end
   end
-  
+
   private
-  
+
   def pet_params
     params.permit(:image, :name, :description, :age, :sex, :status)
   end

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -8,6 +8,7 @@ class Pet < ApplicationRecord
                         :name,
                         :age,
                         :sex
+                        
   def set_defaults
     self.status  ||= 'Adoptable'
   end
@@ -15,7 +16,7 @@ class Pet < ApplicationRecord
   def self.sort_by_status
     Pet.order(status: :asc)
   end
-  
+
   def self.with_application
     Pet.select(:name, :id).joins(:pet_adoptions).uniq
   end

--- a/app/views/adoption_applications/show.html.erb
+++ b/app/views/adoption_applications/show.html.erb
@@ -7,7 +7,7 @@
 <p>Zip: <%= @application.zip %></p>
 <p>Phone: <%= @application.phone%></p>
 <p>Description: <%= @application.description %></p>
-<% @application.pets.each do |pet| %>
-  <p><%= link_to "#{pet.name}", "/pets/#{pet.id}" %> </p>
+<% @application.pet_adoptions.each do |app| %>
+  <section id="#{app.pet.id}"> <p> <%= link_to "Approve application for", "/pets/#{app.pet.id}/pet_adoptions/#{app.id}", method: :patch %> → <%= link_to "#{app.pet.name}", "/pets/#{app.pet.id}" %> </p></section>
 <% end %>
 <hr>

--- a/app/views/pets/show.html.erb
+++ b/app/views/pets/show.html.erb
@@ -8,7 +8,11 @@
 <p>Description: <%= @pet.description %></p>
 <p>Approximate Age: <%= @pet.age %></p>
 <p>Sex: <%= @pet.sex %></p>
-<p>Adoption Status: <%= @pet.status %></p>
+<% if @pet.status == "Pending" %>
+  <p>Adoption Status: <%= @pet.status %> pending application by <%=  @pending_apps.first.adoption_application.name %> </p>
+<% else %>
+  <p>Adoption Status: <%= @pet.status %> </p>
+<% end %>
 <hr>
 <% if favorite_pets.favorited?(@pet.id) %>
   <p><%= link_to "Remove from Favorites", "/favorites/#{@pet.id}", method: :delete %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ Rails.application.routes.draw do
   get '/adoption_applications/new', to: 'adoption_applications#new'
   post '/adoption_applications/new', to: 'adoption_applications#create'
   get "/applications/:application_id", to: "adoption_applications#show"
-  
+
   get '/pets/:id/pet_adoptions', to: 'pet_adoptions#index'
-  
+  patch '/pets/:pet_id/pet_adoptions/:pet_adoption_id', to: 'pet_adoptions#update'
 end

--- a/db/migrate/20200901203807_add_status_to_pet_adoptions.rb
+++ b/db/migrate/20200901203807_add_status_to_pet_adoptions.rb
@@ -1,0 +1,5 @@
+class AddStatusToPetAdoptions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :pet_adoptions, :status, :string, default: "Adoptable"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_31_023651) do
+ActiveRecord::Schema.define(version: 2020_09_01_203807) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 2020_08_31_023651) do
     t.bigint "adoption_application_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "status", default: "Adoptable"
     t.index ["adoption_application_id"], name: "index_pet_adoptions_on_adoption_application_id"
     t.index ["pet_id"], name: "index_pet_adoptions_on_pet_id"
   end

--- a/spec/features/adoption_applications/show_spec.rb
+++ b/spec/features/adoption_applications/show_spec.rb
@@ -54,9 +54,9 @@ RSpec.describe "As a visitor", type: :feature do
   end
 
   it "I can view an application's show page" do
-    
+
     visit "/applications/#{@application_1.id}"
-    
+
     expect(page).to have_content(@application_1.name)
     expect(page).to have_content(@application_1.address)
     expect(page).to have_content(@application_1.city)
@@ -65,13 +65,39 @@ RSpec.describe "As a visitor", type: :feature do
     expect(page).to have_content(@application_1.phone)
     expect(page).to have_link(@pet_1.name)
     expect(page).to have_link(@pet_2.name)
-    
+
     click_link "#{@pet_2.name}"
-    
+
     expect(current_path).to eq("/pets/#{@pet_2.id}")
-            
+
   end
+
+  it "I can approve applications and see the status" do
+
+    visit "/applications/#{@application_1.id}"
+    expect(page).to have_link("Approve application for")
+    click_link("Approve application for", match: :first)
+
+    expect(current_path).to eq("/pets/#{@pet_1.id}")
+    expect(page).to have_content("Pending")
+    expect(page).to have_content("pending application by #{@application_1.name}")
+  end
+
 end
+
+# User Story 22, Approving an Application
+
+# User Story 22
+# As a visitor
+# When I visit an application's show page
+# For every pet that the application is for, I see a link to approve the application for that specific pet
+# When I click on a link to approve the application for one particular pet
+# I'm taken back to that pet's show page
+# And I see that the pets status has changed to 'pending'
+# And I see text on the page that says who this pet is on hold for (Ex: "On hold for John Smith", given John Smith is the name on the application that was just accepted)
+
+
+
 
 # User Story 19, Application Show Page
 #

--- a/user_stories.md
+++ b/user_stories.md
@@ -291,7 +291,7 @@ When I visit a pet applications index page for a pet that has no applications on
 I see a message saying that there are no applications for this pet yet
 
 
-[ ] done
+[x] done
 
 User Story 22, Approving an Application
 
@@ -304,7 +304,7 @@ And I see that the pets status has changed to 'pending'
 And I see text on the page that says who this pet is on hold for (Ex: "On hold for John Smith", given John Smith is the name on the application that was just accepted)
 
 
-[ ] done
+[x] done
 
 User Story 23, Users can get approved to adopt more than one pet
 


### PR DESCRIPTION
User Story 22, Approving an Application

As a visitor
When I visit an application's show page
For every pet that the application is for, I see a link to approve the application for that specific pet
When I click on a link to approve the application for one particular pet
I'm taken back to that pet's show page
And I see that the pets status has changed to 'pending'
And I see text on the page that says who this pet is on hold for (Ex: "On hold for John Smith", given John Smith is the name on the application that was just accepted)
[ ] done

User Story 23, Users can get approved to adopt more than one pet

As a visitor
When an application is made for more than one pet
When I visit that applications show page
I'm able to approve the application for any number of pets