### PR TITLE
User story 24 & 25

### DIFF
--- a/app/controllers/pet_adoptions_controller.rb
+++ b/app/controllers/pet_adoptions_controller.rb
@@ -7,15 +7,18 @@ class PetAdoptionsController < ApplicationController
   def update
     @pet_adoption = PetAdoption.find(params[:pet_adoption_id])
     @pet = Pet.find(params[:pet_id])
-    if @pet.status == "Pending"
+    if @pet.status == "Pending" && @pet_adoption.status == "Pending"
       @pet_adoption.update(status: "Adoptable")
       @pet.update(status: "Adoptable")
       redirect_to "/applications/#{@pet_adoption.adoption_application_id}"
-    else
+    elsif @pet.status == "Adoptable" && @pet_adoption.status == "Adoptable"
       @pet_adoption = PetAdoption.find(params[:pet_adoption_id])
       @pet_adoption.update(status: "Pending")
       @pet.update(status: "Pending")
       redirect_to "/pets/#{params[:pet_id]}"
+    else
+      flash[:error] = "Error, this pet has a pending application"
+      redirect_to "/applications/#{@pet_adoption.adoption_application_id}"
     end
   end
 

--- a/app/controllers/pet_adoptions_controller.rb
+++ b/app/controllers/pet_adoptions_controller.rb
@@ -5,11 +5,18 @@ class PetAdoptionsController < ApplicationController
   end
 
   def update
-    @pet = Pet.find(params[:pet_id])
     @pet_adoption = PetAdoption.find(params[:pet_adoption_id])
-    @pet_adoption.update(status: "Pending")
-    @pet.update(status: "Pending")
-    redirect_to "/pets/#{params[:pet_id]}"
+    @pet = Pet.find(params[:pet_id])
+    if @pet.status == "Pending"
+      @pet_adoption.update(status: "Adoptable")
+      @pet.update(status: "Adoptable")
+      redirect_to "/applications/#{@pet_adoption.adoption_application_id}"
+    else
+      @pet_adoption = PetAdoption.find(params[:pet_adoption_id])
+      @pet_adoption.update(status: "Pending")
+      @pet.update(status: "Pending")
+      redirect_to "/pets/#{params[:pet_id]}"
+    end
   end
 
 end

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -6,7 +6,12 @@ class PetsController < ApplicationController
 
   def show
     @pet = Pet.find(params[:id])
-    @pending_apps = PetAdoption.where(['pet_id = ? and status = ?', "#{@pet.id}", "Pending"])
+    require "pry"; binding.pry
+    if @pet.status == "Pending"
+      @applications = PetAdoption.where(['pet_id = ? and status = ?', "#{@pet.id}", "Pending"])
+    else
+      @applications = PetAdoption.where(['pet_id = ? and status = ?', "#{@pet.id}", "Adoptable"])
+    end
   end
 
   def new

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -6,7 +6,6 @@ class PetsController < ApplicationController
 
   def show
     @pet = Pet.find(params[:id])
-    require "pry"; binding.pry
     if @pet.status == "Pending"
       @applications = PetAdoption.where(['pet_id = ? and status = ?', "#{@pet.id}", "Pending"])
     else

--- a/app/views/adoption_applications/show.html.erb
+++ b/app/views/adoption_applications/show.html.erb
@@ -8,6 +8,10 @@
 <p>Phone: <%= @application.phone%></p>
 <p>Description: <%= @application.description %></p>
 <% @application.pet_adoptions.each do |app| %>
-  <section id="#{app.pet.id}"> <p> <%= link_to "Approve application for", "/pets/#{app.pet.id}/pet_adoptions/#{app.id}", method: :patch %> → <%= link_to "#{app.pet.name}", "/pets/#{app.pet.id}" %> </p></section>
+  <% if app.status == "Adoptable" %>
+    <p> <%= link_to "Approve application for", "/pets/#{app.pet.id}/pet_adoptions/#{app.id}", method: :patch %> → <%= link_to "#{app.pet.name}", "/pets/#{app.pet.id}" %> </p>
+  <% else %>
+    <p> <%= link_to "Revoke application for", "/pets/#{app.pet.id}/pet_adoptions/#{app.id}", method: :patch %> → <%= link_to "#{app.pet.name}", "/pets/#{app.pet.id}" %> </p>
+  <% end %>
 <% end %>
 <hr>

--- a/app/views/pets/show.html.erb
+++ b/app/views/pets/show.html.erb
@@ -9,7 +9,7 @@
 <p>Approximate Age: <%= @pet.age %></p>
 <p>Sex: <%= @pet.sex %></p>
 <% if @pet.status == "Pending" %>
-  <p>Adoption Status: <%= @pet.status %> pending application by <%=  @pending_apps.first.adoption_application.name %> </p>
+  <p>Adoption Status: <%= @pet.status %> application by <%=  @applications.first.adoption_application.name %> </p>
 <% else %>
   <p>Adoption Status: <%= @pet.status %> </p>
 <% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,7 +14,7 @@ shelter2 = Shelter.create!(name: "Pups R Us", address: "222 Sample St", city: "D
 
 pet1 = shelter1.pets.create!(image: "http://www.gsgsrescue.org/assets/files/dogs/2020/06/IMG_1639_1.jpg", name: "Bailey", age: "3", sex: "Female", description: "A good dog", status: "Adoptable")
 pet2 = shelter1.pets.create!(image: "https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/12234558/Chinook-On-White-03.jpg", name: "Ruby", age: "3", sex: "Female", description: "A loving dog", status: "Adoptable")
-pet3 = shelter1.pets.create!(image: "https://www.thesprucepets.com/thmb/kV_cfc9P4QWe-klxZ8y--awxvY4=/960x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/adorable-white-pomeranian-puppy-spitz-921029690-5c8be25d46e0fb000172effe.jpg", name: "Bubba", age: "13", sex: "Male", description: "A fetching good dog", status: "Pending")
+pet3 = shelter1.pets.create!(image: "https://www.thesprucepets.com/thmb/kV_cfc9P4QWe-klxZ8y--awxvY4=/960x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/adorable-white-pomeranian-puppy-spitz-921029690-5c8be25d46e0fb000172effe.jpg", name: "Bubba", age: "13", sex: "Male", description: "A fetching good dog", status: "Adoptable")
 pet4 = shelter2.pets.create!(image: "https://www.sciencemag.org/sites/default/files/styles/article_main_image_-_1280w__no_aspect_/public/pearl_16x9.jpg?itok=tbir55jF", name: "Socks", age: "3", sex: "Female", description: "A nice dog", status: "Adoptable")
 
 # shelter_review1 = shelter1.shelter_reviews.create!(title: "Okay shelter!", rating: 2, content: "Too many sad dogs.", picture: "https://imagesvc.meredithcorp.io/v3/mm/image?url=https%3A%2F%2Fstatic.onecms.io%2Fwp-content%2Fuploads%2Fsites%2F20%2F2019%2F01%2Fpuppies.jpg")

--- a/spec/features/adoption_applications/show_spec.rb
+++ b/spec/features/adoption_applications/show_spec.rb
@@ -50,7 +50,8 @@ RSpec.describe "As a visitor", type: :feature do
     PetAdoption.create!(pet_id: @pet_2.id,
                         adoption_application_id: @application_1.id)
     PetAdoption.create!(pet_id: @pet_2.id,
-                        adoption_application_id: @application_2.id)
+                        adoption_application_id: @application_2.id,
+                        status: "Pending")
   end
 
   it "I can view an application's show page" do
@@ -79,36 +80,46 @@ RSpec.describe "As a visitor", type: :feature do
     click_link("Approve application for", match: :first)
 
     expect(current_path).to eq("/pets/#{@pet_1.id}")
-    expect(page).to have_content("Pending")
-    expect(page).to have_content("pending application by #{@application_1.name}")
+    expect(page).to have_content("Pending application by #{@application_1.name}")
   end
 
+  it "More than one application cannot be approved for a pet" do
+
+    visit "/pets/#{@pet_2.id}"
+
+    visit "/applications/#{@application_1.id}"
+    expect(page).to_not have_link("Revoke application for")
+    click_link("Approve application for", match: :first)
+    expect(page).to have_content("Adoption Status: Pending")
+
+    visit "/applications/#{@application_1.id}"
+    expect(page).to have_link("Revoke application for")
+
+    click_link("Revoke application for", match: :first)
+    expect(current_path).to eq("/applications/#{@application_1.id}")
+    expect(page).to_not have_link("Revoke application for")
+
+    visit "/pets/#{@pet_2.id}"
+    expect(page).to_not have_content("Adoption Status: Pending")
+  end
 end
 
-# User Story 22, Approving an Application
-
-# User Story 22
+# User Story 25
 # As a visitor
-# When I visit an application's show page
-# For every pet that the application is for, I see a link to approve the application for that specific pet
-# When I click on a link to approve the application for one particular pet
-# I'm taken back to that pet's show page
-# And I see that the pets status has changed to 'pending'
-# And I see text on the page that says who this pet is on hold for (Ex: "On hold for John Smith", given John Smith is the name on the application that was just accepted)
+# After an application has been approved for a pet
+# When I visit that applications show page
+# I no longer see a link to approve the application for that pet
+# But I see a link to unapprove the application for that pet
+# When I click on the link to unapprove the application
+# I'm taken back to that applications show page
+# And I can see the button to approve the application for that pet again
+# When I go to that pets show page
+# I can see that the pets adoption status is now back to adoptable
+# And that pet is not on hold anymore
 
 
-
-
-# User Story 19, Application Show Page
-#
 # As a visitor
-# When I visit an applications show page "/applications/:id"
-# I can see the following:
-# - name
-# - address
-# - city
-# - state
-# - zip
-# - phone number
-# - Description of why the applicant says they'd be a good home for this pet(s)
-# - names of all pet's that this application is for (all names of pets should be links to their show page)
+# When a pet has more than one application made for them
+# And one application has already been approved for them
+# I can not approve any other applications for that pet but all other applications still remain on file (they can be seen on the pets application index page)
+# (This can be done by either taking away the option to approve the application, or having a flash message pop up saying that no more applications can be approved for this pet at this time)

--- a/user_stories.md
+++ b/user_stories.md
@@ -316,7 +316,7 @@ I'm able to approve the application for any number of pets
 
 User Story 24, Pets can only have one approved application on them at any time
 
-[ ] done
+[x] done
 
 As a visitor
 When a pet has more than one application made for them


### PR DESCRIPTION
[x] done

As a visitor
When a pet has more than one application made for them
And one application has already been approved for them
I can not approve any other applications for that pet but all other applications still remain on file (they can be seen on the pets application index page)
(This can be done by either taking away the option to approve the application, or having a flash message pop up saying that no more applications can be approved for this pet at this time)