### PR TITLE
User story 26

### DIFF
--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -32,23 +32,33 @@ class SheltersController < ApplicationController
     @shelter = Shelter.find(params[:id])
     @shelter.update(shelter_params)
     if @shelter.save
-      # flash[:success] = "Information successfully updated."
+      flash[:success] = "Information successfully updated."
       redirect_to "/shelters/#{@shelter.id}"
     else
-      # flash[:error] = current_user.errors.full_messages.uniq.to_sentence
-      # redirect_to "/shelters/#{@shelter.id}/edit"
+      flash[:error] = "Unable to save due to missing information."
+      redirect_to "/shelters/#{@shelter.id}"
     end
   end
   
   def destroy
-    Shelter.destroy(params[:id])
-    redirect_to "/shelters"
+    @shelter = Shelter.find(params[:id])
+    if pending_pets?
+      flash[:error] = "Can't delete #{@shelter.name}, it has pending pet applications..."
+      redirect_to "/shelters/#{@shelter.id}"
+    else
+      Shelter.destroy(params[:id])
+      redirect_to "/shelters"
+    end
   end
   
   private
   
   def shelter_params
     params.permit(:name, :address, :city, :state, :zip)
+  end
+  
+  def pending_pets?
+    @shelter.pets.any? {|pet| pet.status == "Pending"}
   end
   
 end

--- a/user_stories.md
+++ b/user_stories.md
@@ -347,7 +347,7 @@ Shelters
 
 Visitors will have additional constraints when manipulating shelter data in the database.
 
-[ ] done
+[x] done
 
 User Story 26, Shelters with Pets that have pending status cannot be Deleted
 
@@ -357,7 +357,9 @@ I can not delete that shelter
 Either:
 - there is no button visible for me to delete the shelter
 - if I click on the delete link for deleting a shelter, I see a flash message indicating that the shelter can not be deleted.
-[ ] done
+
+
+[x] done
 
 User Story 27, Shelters can be Deleted as long as all pets do not have approved applications on them
 
@@ -366,7 +368,9 @@ If a shelter doesn't have any pets with a pending status
 I can delete that shelter
 When that shelter is deleted
 Then all of their pets are deleted as well
-[ ] done
+
+
+[x] done
 
 User Story 28, Deleting Shelters Deletes its Reviews
 


### PR DESCRIPTION
User Story 26, Shelters with Pets that have pending status cannot be Deleted

As a visitor
If a shelter has approved applications for any of their pets
I can not delete that shelter
Either:
- there is no button visible for me to delete the shelter
- if I click on the delete link for deleting a shelter, I see a flash message indicating that the shelter can not be deleted.