### PR TITLE
User story 26, 27 & 28

### DIFF
--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -32,23 +32,33 @@ class SheltersController < ApplicationController
     @shelter = Shelter.find(params[:id])
     @shelter.update(shelter_params)
     if @shelter.save
-      # flash[:success] = "Information successfully updated."
+      flash[:success] = "Information successfully updated."
       redirect_to "/shelters/#{@shelter.id}"
     else
-      # flash[:error] = current_user.errors.full_messages.uniq.to_sentence
-      # redirect_to "/shelters/#{@shelter.id}/edit"
+      flash[:error] = "Unable to save due to missing information."
+      redirect_to "/shelters/#{@shelter.id}"
     end
   end
   
   def destroy
-    Shelter.destroy(params[:id])
-    redirect_to "/shelters"
+    @shelter = Shelter.find(params[:id])
+    if pending_pets?
+      flash[:error] = "Can't delete #{@shelter.name}, it has pending pet applications..."
+      redirect_to "/shelters/#{@shelter.id}"
+    else
+      Shelter.destroy(params[:id])
+      redirect_to "/shelters"
+    end
   end
   
   private
   
   def shelter_params
     params.permit(:name, :address, :city, :state, :zip)
+  end
+  
+  def pending_pets?
+    @shelter.pets.any? {|pet| pet.status == "Pending"}
   end
   
 end

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -1,14 +1,14 @@
 class Pet < ApplicationRecord
 
   belongs_to :shelter
-  has_many :pet_adoptions
+  has_many :pet_adoptions, dependent: :delete_all
   has_many :adoption_applications, through: :pet_adoptions
 
   validates_presence_of :image,
                         :name,
                         :age,
                         :sex
-                        
+
   def set_defaults
     self.status  ||= 'Adoptable'
   end

--- a/app/models/pet_adoption.rb
+++ b/app/models/pet_adoption.rb
@@ -4,6 +4,7 @@ class PetAdoption < ApplicationRecord
   belongs_to :adoption_application
 
   validates_presence_of :pet_id,
-                        :adoption_application_id
+                        :adoption_application_id,
+                        :status
 
 end

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -1,6 +1,7 @@
 class Shelter < ApplicationRecord
-  has_many :pets
-  has_many :shelter_reviews
+  has_many :pets, dependent: :destroy
+  has_many :shelter_reviews, dependent: :delete_all
+
   validates_presence_of :name,
                         :address,
                         :city,

--- a/app/models/shelter_review.rb
+++ b/app/models/shelter_review.rb
@@ -1,8 +1,7 @@
 class ShelterReview < ApplicationRecord
   belongs_to :shelter
+
   validates_presence_of :title,
                         :rating,
                         :content
-
-
 end

--- a/spec/features/shelters/destroy_spec.rb
+++ b/spec/features/shelters/destroy_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe "As a visitor", type: :feature do
-  
+
   before(:each) do
     @shelter_1 = Shelter.create({
             name: "Primary Shelter",
@@ -17,35 +17,65 @@ RSpec.describe "As a visitor", type: :feature do
             state: "WY",
             zip: "33221"
             })
+
+    @pet_1 = @shelter_1.pets.create!(
+              image: "https://allaboutshepherds.com/wp-content/uploads/2016/05/gsd-canoe.jpg",
+              name: "Bailey",
+              age: "3",
+              sex: "Female",
+              description: "She's a 85 pound lap dog!",
+              status: "Adoptable"
+              )
+
+    @application_1 = AdoptionApplication.create!(
+      name: "Bob",
+      address: "123 Maple Ave.",
+      city: "Denver",
+      state: "CO",
+      zip: "80438",
+      phone: "8675309",
+      description: "I am a semi-good pet owner"
+      )
+
+    PetAdoption.create!(pet_id: @pet_1.id,
+                        adoption_application_id: @application_1.id,
+                        status: "Pending")
   end
-  
+
   it "When I visit /shelters/:id I can click a link to delete a shelter" do
 
     visit "/shelters/#{@shelter_1.id}"
 
     expect(Shelter.first.name).to eq("Primary Shelter")
-  
+
     expect(page).to have_link("Delete Shelter")
-    
+
     click_link "Delete Shelter"
 
     expect(current_path).to eq("/shelters")
-    
+
     expect(Shelter.first.name).to eq("Secondary Shelter")
   end
-  
+
   it "When I visit /shelters I can click a link to delete a shelter" do
 
     visit "/shelters"
 
     expect(Shelter.first.name).to eq("Primary Shelter")
-  
+
     expect(page).to have_link("Delete Shelter")
-    
+
     click_link("Delete Shelter", match: :first)
 
     expect(current_path).to eq("/shelters")
-    
+
     expect(Shelter.first.name).to eq("Secondary Shelter")
+  end
+
+  it "A shelter with pending pets cannot be deleted" do
+
+    visit("/shelters/#{@shelter_1.id}")
+    click_link("Delete Shelter")
+    expect(page).to have_content("Shelter cannot be deleted due to pending applications")
   end
 end

--- a/user_stories.md
+++ b/user_stories.md
@@ -347,7 +347,7 @@ Shelters
 
 Visitors will have additional constraints when manipulating shelter data in the database.
 
-[ ] done
+[x] done
 
 User Story 26, Shelters with Pets that have pending status cannot be Deleted
 
@@ -357,7 +357,9 @@ I can not delete that shelter
 Either:
 - there is no button visible for me to delete the shelter
 - if I click on the delete link for deleting a shelter, I see a flash message indicating that the shelter can not be deleted.
-[ ] done
+
+
+[x] done
 
 User Story 27, Shelters can be Deleted as long as all pets do not have approved applications on them
 
@@ -366,7 +368,9 @@ If a shelter doesn't have any pets with a pending status
 I can delete that shelter
 When that shelter is deleted
 Then all of their pets are deleted as well
-[ ] done
+
+
+[x] done
 
 User Story 28, Deleting Shelters Deletes its Reviews
 


### PR DESCRIPTION
[x] done

User Story 26, Shelters with Pets that have pending status cannot be Deleted

As a visitor
If a shelter has approved applications for any of their pets
I can not delete that shelter
Either:
- there is no button visible for me to delete the shelter
- if I click on the delete link for deleting a shelter, I see a flash message indicating that the shelter can not be deleted.


[x] done

User Story 27, Shelters can be Deleted as long as all pets do not have approved applications on them

As a visitor
If a shelter doesn't have any pets with a pending status
I can delete that shelter
When that shelter is deleted
Then all of their pets are deleted as well


[x] done

User Story 28, Deleting Shelters Deletes its Reviews

As a visitor
When I delete a shelter
All reviews associated with that shelter are also deleted