### PR TITLE
User story 31 & 32

### DIFF
--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -49,7 +49,7 @@ class PetsController < ApplicationController
   def destroy
     pet = Pet.find(params[:id])
     if pet.status == "Pending"
-      # flash[:notice] = "Unable to delete #{pet.name} because it has an approved application"
+      flash[:error] = "Unable to delete #{pet.name} because it has an approved application"
       redirect_to "/pets/#{pet.id}"
     else
       # session[:favorites].delete(pet.id.to_s) if session[:favorites] != nil

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -52,7 +52,7 @@ class PetsController < ApplicationController
       flash[:error] = "Unable to delete #{pet.name} because it has an approved application"
       redirect_to "/pets/#{pet.id}"
     else
-      # session[:favorites].delete(pet.id.to_s) if session[:favorites] != nil
+      session[:favorites].delete(params[:id]) if !session[:favorites].nil?
       Pet.destroy(params[:id])
       redirect_to "/pets"
     end

--- a/spec/features/favorites/delete_spec.rb
+++ b/spec/features/favorites/delete_spec.rb
@@ -112,5 +112,31 @@ RSpec.describe "As a visitor", type: :feature do
       expect(page).to have_link("Favorites - 0")
     end
   end
+  
+  it "When i delete a pet it removes it from favorites" do
+
+    pet_2 = @shelter_1.pets.create!(
+              image: "https://i.pinimg.com/originals/ea/cd/6a/eacd6a5cbcf58c93fa4cfc4d83159896.jpg",
+              name: "Bruiser",
+              age: "2",
+              sex: "Male",
+              description: "He's a 185 pound lap dog!",
+              status: "Adoptable"
+              )
+
+    visit "/pets/#{@pet_1.id}"
+    expect(page).to have_link("Add to Favorites")
+    click_link("Add to Favorites")
+    within "navbar" do
+      expect(page).to have_link("Favorites - 1")
+    end
+    
+    click_link "Delete Pet"
+    
+    within "navbar" do
+      expect(page).to have_link("Favorites - 0")
+    end
+
+  end
 end
 

--- a/spec/features/pet_adoptions/index_spec.rb
+++ b/spec/features/pet_adoptions/index_spec.rb
@@ -77,11 +77,29 @@ RSpec.describe "As a visitor", type: :feature do
 
   it "I am not able to approve an application for a pet with an existig approved application" do
 
-  PetAdoption.create!(pet_id: @pet_1.id,
+    shelter_1 = Shelter.create({
+            name: "Primary Shelter",
+            address: "123 Maple Ave.",
+            city: "Denver",
+            state: "CO",
+            zip: "80438"
+            })
+
+    pet_1 = shelter_1.pets.create!(
+              image: "https://allaboutshepherds.com/wp-content/uploads/2016/05/gsd-canoe.jpg",
+              name: "Bailey",
+              age: "3",
+              sex: "Female",
+              description: "She's a 85 pound lap dog!",
+              status: "Adoptable"
+              )
+
+  PetAdoption.create!(pet_id: pet_1.id,
                       adoption_application_id: @application_1.id,
                       status: "Pending")
-  PetAdoption.create!(pet_id: @pet_1.id,
-                      adoption_application_id: @application_2.id)
+  
+                      
+                      
 
   visit("/applications/#{@application_1.id}")
   end

--- a/spec/features/pets/update_spec.rb
+++ b/spec/features/pets/update_spec.rb
@@ -113,4 +113,5 @@ RSpec.describe "As a visitor", type: :feature do
     expect(page).to have_content("Sex: Male")
     expect(page).to have_content("Description: Pet with updated information")
   end
+  
 end

--- a/spec/features/shelters/show_spec.rb
+++ b/spec/features/shelters/show_spec.rb
@@ -93,7 +93,6 @@ RSpec.describe "As a visitor", type: :feature do
   it "When I visit /shelters/:id I see some statistics pertaining to this shelter" do
     
   visit "/shelters/#{@shelter_1.id}"
-  save_and_open_page
   
   expect(page).to have_content("3")
   expect(page).to have_content("2")

--- a/spec/models/pet_spec.rb
+++ b/spec/models/pet_spec.rb
@@ -11,4 +11,26 @@ describe Pet, type: :model do
   describe "relationships" do
     it {should belong_to :shelter}
   end
+  
+  it "returns a status" do
+    @shelter_1 = Shelter.create({
+            name: "Primary Shelter",
+            address: "123 Maple Ave.",
+            city: "Denver",
+            state: "CO",
+            zip: "80438"
+            })
+            
+    @pet_1 = @shelter_1.pets.create!(
+            image: "https://allaboutshepherds.com/wp-content/uploads/2016/05/gsd-canoe.jpg",
+            name: "Bailey",
+            age: "3",
+            sex: "Female",
+            description: "She's a 85 pound lap dog!",
+            status: "Adoptable"
+            )
+  expected = Pet.last
+  expect(Pet.sort_by_status).to eq(Pet.sort_by_status)
+  expect(@pet_1.set_defaults).to eq("Adoptable")
+  end
 end

--- a/user_stories.md
+++ b/user_stories.md
@@ -405,7 +405,7 @@ Pet
 
 Visitors will have additional constraints when manipulating pet data in the database.
 
-[ ] done
+[x] done
 
 User Story 31, Pets with approved applications cannot be deleted
 
@@ -415,7 +415,9 @@ I can not delete that pet
 Either:
 - there is no button visible for me to delete the pet
 - if I click on the delete button, I see a flash message indicating that the pet can not be deleted.
-[ ] done
+
+
+[x] done
 
 User Story 32, Deleting a pet removes it from favorites
 


### PR DESCRIPTION
[x] done

User Story 31, Pets with approved applications cannot be deleted

As a visitor
If a pet has an approved application on them
I can not delete that pet
Either:
- there is no button visible for me to delete the pet
- if I click on the delete button, I see a flash message indicating that the pet can not be deleted.


[x] done

User Story 32, Deleting a pet removes it from favorites

As a visitor
If I've added a pet to my favorites
When I try to delete that pet from the database
They are also removed from the favorites list