### PR TITLE
User story 38

### DIFF
--- a/app/views/shelters/show.html.erb
+++ b/app/views/shelters/show.html.erb
@@ -13,7 +13,11 @@
 <h2>Reviews:</h2>
 <% @shelter.shelter_reviews.each do |review|%>
   <section id="review-<%=review.id%>">
-    <img src= <%=review.image %>>
+    <% if review.image == "" %>
+      <img src= <%= "https://innovationlabs.harvard.edu/wp-content/uploads/sites/5/2018/08/Coming-soon-stamp-300x150.jpg" %>>
+    <% else %>
+      <img src= <%=review.image %>>
+    <% end %>
     <p>Title: <%= review.title %></p>
     <p>Rating: <%= review.rating %></p>
     <p>Content: <%= review.content %></p

--- a/spec/features/shelter_reviews/new_spec.rb
+++ b/spec/features/shelter_reviews/new_spec.rb
@@ -50,4 +50,26 @@ RSpec.describe "As a visitor", type: :feature do
 
     expect(current_path).to eq("/shelters/#{@shelter_1.id}/reviews/new")
   end
+  
+  it "If I do not supply an image I get a image placeholder" do
+
+    visit "/shelters/#{@shelter_1.id}"
+
+    click_on "New Review"
+
+    expect(current_path).to eq("/shelters/#{@shelter_1.id}/reviews/new")
+
+    fill_in 'Title', with: "Review string"
+    fill_in 'Rating', with: "Review rating"
+    fill_in 'Content', with: "Review content"
+
+    click_on "Create Review"
+    expect(current_path).to eq("/shelters/#{@shelter_1.id}")
+
+    expect(page).to have_content("Review string")
+    expect(page).to have_content("Review rating")
+    expect(page).to have_content("Review content")
+    save_and_open_page
+    expect(page).to have_css("img[src*='https://innovationlabs.harvard.edu/wp-content/uploads/sites/5/2018/08/Coming-soon-stamp-300x150.jpg']")
+  end
 end

--- a/user_stories.md
+++ b/user_stories.md
@@ -425,7 +425,9 @@ As a visitor
 If I've added a pet to my favorites
 When I try to delete that pet from the database
 They are also removed from the favorites list
-[ ] done
+
+
+[x] done
 
 User Story 33, Flash Message for Pet Create and Update
 
@@ -439,7 +441,7 @@ Usability
 
 Visitors will have additional constraints when manipulating pet data in the database.
 
-[ ] done
+[x] done
 
 User Story 34, All Pet Names are links to that Pet's Show Page
 
@@ -460,6 +462,11 @@ User Story 36, All Applicant Names are links to that Applicant's application
 As a visitor
 Any time I see an applicant's name within this application
 It is a link to their application show page
+
+
+
+
+
 Extensions
 
 User Story 37, List of Pets with Approved Applications
@@ -471,7 +478,8 @@ After an application has been approved for one or more pets
 When I visit the favorites page
 I see a section on the page that has a list of all of the pets that have an approved application on them
 Each pet's name is a link to their show page
-[ ] done
+
+[x] done
 
 User Story 38, Reviews have a default picture
 


### PR DESCRIPTION
[x] done

User Story 38, Reviews have a default picture

As a visitor
When I create a review for a shelter
And do not fill in the field for an image
A default image is used and displayed for that review upon submission